### PR TITLE
pmap/ndr-gpm1: accessing ptype_head can be dangerous

### DIFF
--- a/drivers/pktmap/ndr-gpm1/ngpm1_skbhook.c
+++ b/drivers/pktmap/ndr-gpm1/ngpm1_skbhook.c
@@ -113,7 +113,7 @@ int ngpm1_skbhook_attach( uint16_t type, int (*ptr_hook_func)( NGPM1_SKBHOOK_ARG
 	while ( !!(pt_iter = ngpm1_ptype_entry_rcu( shdesc->type, &(shdesc->pt.list) )) )
 	{
 		dev_remove_pack( pt_iter );
-		if ( pt_prev )
+		if ( pt_prev && pt_prev->list.prev == LIST_POISON2 )
 		{
 			list_add_rcu( &(pt_prev->list), &(shdesc->ptlist) );
 		}
@@ -169,7 +169,10 @@ int ngpm1_skbhook_detach( uint16_t type )
 	while ( !!(pt_iter = ngpm1_ptype_entry_rcu( shdesc->type, &(shdesc->pt.list) )) )
 	{
 		dev_remove_pack( pt_iter );
-		list_add_rcu( &(pt_iter->list), &(shdesc->ptlist) );
+		if ( pt_iter->list.prev == LIST_POISON2 )
+		{
+			list_add_rcu( &(pt_iter->list), &(shdesc->ptlist) );
+		}
 	}
 
 	/* Step 2: Remove the skbhook */


### PR DESCRIPTION
ngpm1_skbhook_attach & ngpm1_skbhook_detach can be a cause of kernel panic.
It accesses and manipulates entries of ptype_list regardless of the entry is a ptype_head or not.
So, I added some LIST_POISON checking routines to protect the ptype_head from list_add/del routines.