### PR TITLE
comp/gcc: introduce cmplxt (complex type)

### DIFF
--- a/archdeps/x86/ndrte_arch_endian.h
+++ b/archdeps/x86/ndrte_arch_endian.h
@@ -76,6 +76,6 @@ static NDRTE_STRONG_INLINE uint64_t ndrte_endian_conv64( uint64_t u64 )
 	ndrte_builtin_const( x ) ? NDRTE_ENDIAN_INTERNAL_IFCONST( x, size, endian ) : NDRTE_ENDIAN_INTERNAL_IF( x, size, endian )
 
 #define ndrte_endian_conv( x, size, endian ) \
-	ndrte_endian_conv_generic( x, size, NDRTE_ENDIAN_INTERNAL_##endian )
+	ndrte_endian_conv_generic( x, size, NDRTE_ENDIAN_INTERNAL_ ## endian )
 
 #endif

--- a/compdeps/gcc/Makefile
+++ b/compdeps/gcc/Makefile
@@ -1,3 +1,6 @@
+HDRS += ndrte_compiler_cmplxt_define.h
+HDRS += ndrte_compiler_cmplxt_pack.h
+HDRS += ndrte_compiler_cmplxt_split.h
 HDRS += ndrte_compiler_common.h
 
 include $(NBE_DIR)/ndr.obj.mk

--- a/compdeps/gcc/ndrte_compiler_cmplxt_define.h
+++ b/compdeps/gcc/ndrte_compiler_cmplxt_define.h
@@ -1,0 +1,59 @@
+#ifdef NDRTE_COMPILER_COMMON_H
+
+#define NDRTE_CMPLXT_COMMON_TCHK_1( ctype, arg, ... ) \
+	ndrte_typechk( ctype, arg )
+#define NDRTE_CMPLXT_COMMON_TCHK_2( ctype, arg, ... ) \
+	ndrte_typechk( ctype, arg ); \
+	NDRTE_CMPLXT_COMMON_TCHK_1( ctype, __VA_ARGS__ )
+#define NDRTE_CMPLXT_COMMON_TCHK_3( ctype, arg, ... ) \
+	ndrte_typechk( ctype, arg ); \
+	NDRTE_CMPLXT_COMMON_TCHK_2( ctype, __VA_ARGS__ )
+#define NDRTE_CMPLXT_COMMON_TCHK_4( ctype, arg, ... ) \
+	ndrte_typechk( ctype, arg ); \
+	NDRTE_CMPLXT_COMMON_TCHK_3( ctype, __VA_ARGS__ )
+#define NDRTE_CMPLXT_COMMON_TCHK_5( ctype, arg, ... ) \
+	ndrte_typechk( ctype, arg ); \
+	NDRTE_CMPLXT_COMMON_TCHK_4( ctype, __VA_ARGS__ )
+#define NDRTE_CMPLXT_COMMON_TCHK_6( ctype, arg, ... ) \
+	ndrte_typechk( ctype, arg ); \
+	NDRTE_CMPLXT_COMMON_TCHK_5( ctype, __VA_ARGS__ )
+#define NDRTE_CMPLXT_COMMON_TCHK_7( ctype, arg, ... ) \
+	ndrte_typechk( ctype, arg ); \
+	NDRTE_CMPLXT_COMMON_TCHK_6( ctype, __VA_ARGS__ )
+#define NDRTE_CMPLXT_COMMON_TCHK_8( ctype, arg, ... ) \
+	ndrte_typechk( ctype, arg ); \
+	NDRTE_CMPLXT_COMMON_TCHK_7( ctype, __VA_ARGS__ )
+#define NDRTE_CMPLXT_COMMON_TCHK_9( ctype, arg, ... ) \
+	ndrte_typechk( ctype, arg ); \
+	NDRTE_CMPLXT_COMMON_TCHK_8( ctype, __VA_ARGS__ )
+#define NDRTE_CMPLXT_COMMON_TCHK_10( ctype, arg, ... ) \
+	ndrte_typechk( ctype, arg ); \
+	NDRTE_CMPLXT_COMMON_TCHK_9( ctype, __VA_ARGS__ )
+#define NDRTE_CMPLXT_COMMON_TCHK_11( ctype, arg, ... ) \
+	ndrte_typechk( ctype, arg ); \
+	NDRTE_CMPLXT_COMMON_TCHK_10( ctype, __VA_ARGS__ )
+#define NDRTE_CMPLXT_COMMON_TCHK_12( ctype, arg, ... ) \
+	ndrte_typechk( ctype, arg ); \
+	NDRTE_CMPLXT_COMMON_TCHK_11( ctype, __VA_ARGS__ )
+#define NDRTE_CMPLXT_COMMON_TCHK_13( ctype, arg, ... ) \
+	ndrte_typechk( ctype, arg ); \
+	NDRTE_CMPLXT_COMMON_TCHK_12( ctype, __VA_ARGS__ )
+#define NDRTE_CMPLXT_COMMON_TCHK_14( ctype, arg, ... ) \
+	ndrte_typechk( ctype, arg ); \
+	NDRTE_CMPLXT_COMMON_TCHK_13( ctype, __VA_ARGS__ )
+#define NDRTE_CMPLXT_COMMON_TCHK_15( ctype, arg, ... ) \
+	ndrte_typechk( ctype, arg ); \
+	NDRTE_CMPLXT_COMMON_TCHK_14( ctype, __VA_ARGS__ )
+#define NDRTE_CMPLXT_COMMON_TCHK_16( ctype, arg, ... ) \
+	ndrte_typechk( ctype, arg ); \
+	NDRTE_CMPLXT_COMMON_TCHK_15( ctype, __VA_ARGS__ )
+#define NDRTE_CMPLXT_COMMON_TCHK_( N, ctype, arg, ... ) NDRTE_PP_CAT( NDRTE_CMPLXT_COMMON_TCHK_, N ) ( ctype, arg, __VA_ARGS__ )
+#define NDRTE_CMPLXT_COMMON_TCHK( ctype, arg, ... ) NDRTE_CMPLXT_COMMON_TCHK_( NDRTE_PP_NARG( arg, __VA_ARGS__), ctype, arg, __VA_ARGS__ )
+
+typedef int ndrte_int64_t __attribute__((__mode__(__DI__)));
+typedef unsigned int ndrte_uint64_t __attribute__((__mode__(__DI__))) ;
+
+typedef int ndrte_int128_t __attribute__((__mode__(__TI__))) ;
+typedef unsigned int ndrte_uint128_t __attribute__((__mode__(__TI__))) ;
+
+#endif

--- a/compdeps/gcc/ndrte_compiler_cmplxt_pack.h
+++ b/compdeps/gcc/ndrte_compiler_cmplxt_pack.h
@@ -1,0 +1,95 @@
+#ifdef NDRTE_COMPILER_COMMON_H
+
+#define NDRTE_CMPLXT_PACK_ASSIGN_1( tvar, csize, arg, ... ) \
+	tvar |= arg & NDRTE_PP_CAT( NDRTE_PP_CAT( UINT, csize ), _MAX)
+#define NDRTE_CMPLXT_PACK_ASSIGN_2( tvar, csize, arg, ... ) \
+	NDRTE_CMPLXT_PACK_ASSIGN_1( tvar, csize, __VA_ARGS__ ); \
+	tvar <<= csize; \
+	tvar |= arg & NDRTE_PP_CAT( NDRTE_PP_CAT( UINT, csize ), _MAX)
+#define NDRTE_CMPLXT_PACK_ASSIGN_3( tvar, csize, arg, ... ) \
+	NDRTE_CMPLXT_PACK_ASSIGN_2( tvar, csize, __VA_ARGS__ ); \
+	tvar <<= csize; \
+	tvar |= arg & NDRTE_PP_CAT( NDRTE_PP_CAT( UINT, csize ), _MAX)
+#define NDRTE_CMPLXT_PACK_ASSIGN_4( tvar, csize, arg, ... ) \
+	NDRTE_CMPLXT_PACK_ASSIGN_3( tvar, csize, __VA_ARGS__ ); \
+	tvar <<= csize; \
+	tvar |= arg & NDRTE_PP_CAT( NDRTE_PP_CAT( UINT, csize ), _MAX)
+#define NDRTE_CMPLXT_PACK_ASSIGN_5( tvar, csize, arg, ... ) \
+	NDRTE_CMPLXT_PACK_ASSIGN_4( tvar, csize, __VA_ARGS__ ); \
+	tvar <<= csize; \
+	tvar |= arg & NDRTE_PP_CAT( NDRTE_PP_CAT( UINT, csize ), _MAX)
+#define NDRTE_CMPLXT_PACK_ASSIGN_6( tvar, csize, arg, ... ) \
+	NDRTE_CMPLXT_PACK_ASSIGN_5( tvar, csize, __VA_ARGS__ ); \
+	tvar <<= csize; \
+	tvar |= arg & NDRTE_PP_CAT( NDRTE_PP_CAT( UINT, csize ), _MAX)
+#define NDRTE_CMPLXT_PACK_ASSIGN_7( tvar, csize, arg, ... ) \
+	NDRTE_CMPLXT_PACK_ASSIGN_6( tvar, csize, __VA_ARGS__ ); \
+	tvar <<= csize; \
+	tvar |= arg & NDRTE_PP_CAT( NDRTE_PP_CAT( UINT, csize ), _MAX)
+#define NDRTE_CMPLXT_PACK_ASSIGN_8( tvar, csize, arg, ... ) \
+	NDRTE_CMPLXT_PACK_ASSIGN_7( tvar, csize, __VA_ARGS__ ); \
+	tvar <<= csize; \
+	tvar |= arg & NDRTE_PP_CAT( NDRTE_PP_CAT( UINT, csize ), _MAX)
+#define NDRTE_CMPLXT_PACK_ASSIGN_9( tvar, csize, arg, ... ) \
+	NDRTE_CMPLXT_PACK_ASSIGN_8( tvar, csize, __VA_ARGS__ ); \
+	tvar <<= csize; \
+	tvar |= arg & NDRTE_PP_CAT( NDRTE_PP_CAT( UINT, csize ), _MAX)
+#define NDRTE_CMPLXT_PACK_ASSIGN_10( tvar, csize, arg, ... ) \
+	NDRTE_CMPLXT_PACK_ASSIGN_9( tvar, csize, __VA_ARGS__ ); \
+	tvar <<= csize; \
+	tvar |= arg & NDRTE_PP_CAT( NDRTE_PP_CAT( UINT, csize ), _MAX)
+#define NDRTE_CMPLXT_PACK_ASSIGN_11( tvar, csize, arg, ... ) \
+	NDRTE_CMPLXT_PACK_ASSIGN_10( tvar, csize, __VA_ARGS__ ); \
+	tvar <<= csize; \
+	tvar |= arg & NDRTE_PP_CAT( NDRTE_PP_CAT( UINT, csize ), _MAX)
+#define NDRTE_CMPLXT_PACK_ASSIGN_12( tvar, csize, arg, ... ) \
+	NDRTE_CMPLXT_PACK_ASSIGN_11( tvar, csize, __VA_ARGS__ ); \
+	tvar <<= csize; \
+	tvar |= arg & NDRTE_PP_CAT( NDRTE_PP_CAT( UINT, csize ), _MAX)
+#define NDRTE_CMPLXT_PACK_ASSIGN_13( tvar, csize, arg, ... ) \
+	NDRTE_CMPLXT_PACK_ASSIGN_12( tvar, csize, __VA_ARGS__ ); \
+	tvar <<= csize; \
+	tvar |= arg & NDRTE_PP_CAT( NDRTE_PP_CAT( UINT, csize ), _MAX)
+#define NDRTE_CMPLXT_PACK_ASSIGN_14( tvar, csize, arg, ... ) \
+	NDRTE_CMPLXT_PACK_ASSIGN_13( tvar, csize, __VA_ARGS__ ); \
+	tvar <<= csize; \
+	tvar |= arg & NDRTE_PP_CAT( NDRTE_PP_CAT( UINT, csize ), _MAX)
+#define NDRTE_CMPLXT_PACK_ASSIGN_15( tvar, csize, arg, ... ) \
+	NDRTE_CMPLXT_PACK_ASSIGN_14( tvar, csize, __VA_ARGS__ ); \
+	tvar <<= csize; \
+	tvar |= arg & NDRTE_PP_CAT( NDRTE_PP_CAT( UINT, csize ), _MAX)
+#define NDRTE_CMPLXT_PACK_ASSIGN_16( tvar, csize, arg, ... ) \
+	NDRTE_CMPLXT_PACK_ASSIGN_15( tvar, csize, __VA_ARGS__ ); \
+	tvar <<= csize; \
+	tvar |= arg & NDRTE_PP_CAT( NDRTE_PP_CAT( UINT, csize ), _MAX)
+
+#define NDRTE_CMPLXT_PACK_ASSIGN_( N, tvar, csize, arg, ... ) NDRTE_PP_CAT( NDRTE_CMPLXT_PACK_ASSIGN_, N ) ( tvar, csize, arg, __VA_ARGS__ )
+#define NDRTE_CMPLXT_PACK_ASSIGN( tvar, csize, arg, ... ) NDRTE_CMPLXT_PACK_ASSIGN_( NDRTE_PP_NARG( arg, __VA_ARGS__ ), tvar, csize, arg, __VA_ARGS__ )
+
+#define ndrte_cmplxt_pack_generic( tvar, csize, ... ) \
+	NDRTE_CMPLXT_PACK_ASSIGN( tvar, csize, __VA_ARGS__ )
+
+#define ndrte_cmplxt_pack_signed( tvar, csize, ... ) \
+	{ \
+		tvar = 0; \
+		ndrte_cmplxt_pack_generic( tvar, csize, __VA_ARGS__ ); \
+	}
+#define ndrte_cmplxt_pack_unsigned( tvar, csize, ... ) \
+	{ \
+		tvar = 0; \
+		ndrte_cmplxt_pack_generic( tvar, csize, __VA_ARGS__ ); \
+	}
+#define ndrte_cmplxt_pack_signed_safe( tvar, csize, ... ) \
+	{ \
+		tvar = 0; \
+		NDRTE_CMPLXT_COMMON_TCHK( NDRTE_PP_CAT(NDRTE_PP_CAT( int, csize ), _t ), __VA_ARGS__ ); \
+		ndrte_cmplxt_pack_generic( tvar, csize, __VA_ARGS__ ); \
+	}
+#define ndrte_cmplxt_pack_unsigned_safe( tvar, csize, ... ) \
+	{ \
+		tvar = 0; \
+		NDRTE_CMPLXT_COMMON_TCHK( NDRTE_PP_CAT(NDRTE_PP_CAT( uint, csize ), _t ), __VA_ARGS__ ); \
+		ndrte_cmplxt_pack_generic( tvar, csize, __VA_ARGS__ ); \
+	}
+
+#endif

--- a/compdeps/gcc/ndrte_compiler_cmplxt_split.h
+++ b/compdeps/gcc/ndrte_compiler_cmplxt_split.h
@@ -1,0 +1,79 @@
+#ifdef NDRTE_COMPILER_COMMON_H
+
+#define NDRTE_CMPLXT_SPLIT_ASSIGN_1( tvar, csize, arg, ... ) \
+	arg = tvar & NDRTE_PP_CAT( NDRTE_PP_CAT( UINT, csize ), _MAX); tvar >>= csize
+#define NDRTE_CMPLXT_SPLIT_ASSIGN_2( tvar, csize, arg, ... ) \
+	arg = tvar & NDRTE_PP_CAT( NDRTE_PP_CAT( UINT, csize ), _MAX); tvar >>= csize; \
+	NDRTE_CMPLXT_SPLIT_ASSIGN_1( tvar, csize, __VA_ARGS__ )
+#define NDRTE_CMPLXT_SPLIT_ASSIGN_3( tvar, csize, arg, ... ) \
+	arg = tvar & NDRTE_PP_CAT( NDRTE_PP_CAT( UINT, csize ), _MAX); tvar >>= csize; \
+	NDRTE_CMPLXT_SPLIT_ASSIGN_2( tvar, csize, __VA_ARGS__ )
+#define NDRTE_CMPLXT_SPLIT_ASSIGN_4( tvar, csize, arg, ... ) \
+	arg = tvar & NDRTE_PP_CAT( NDRTE_PP_CAT( UINT, csize ), _MAX); tvar >>= csize; \
+	NDRTE_CMPLXT_SPLIT_ASSIGN_3( tvar, csize, __VA_ARGS__ )
+#define NDRTE_CMPLXT_SPLIT_ASSIGN_5( tvar, csize, arg, ... ) \
+	arg = tvar & NDRTE_PP_CAT( NDRTE_PP_CAT( UINT, csize ), _MAX); tvar >>= csize; \
+	NDRTE_CMPLXT_SPLIT_ASSIGN_4( tvar, csize, __VA_ARGS__ )
+#define NDRTE_CMPLXT_SPLIT_ASSIGN_6( tvar, csize, arg, ... ) \
+	arg = tvar & NDRTE_PP_CAT( NDRTE_PP_CAT( UINT, csize ), _MAX); tvar >>= csize; \
+	NDRTE_CMPLXT_SPLIT_ASSIGN_5( tvar, csize, __VA_ARGS__ )
+#define NDRTE_CMPLXT_SPLIT_ASSIGN_7( tvar, csize, arg, ... ) \
+	arg = tvar & NDRTE_PP_CAT( NDRTE_PP_CAT( UINT, csize ), _MAX); tvar >>= csize; \
+	NDRTE_CMPLXT_SPLIT_ASSIGN_6( tvar, csize, __VA_ARGS__ )
+#define NDRTE_CMPLXT_SPLIT_ASSIGN_8( tvar, csize, arg, ... ) \
+	arg = tvar & NDRTE_PP_CAT( NDRTE_PP_CAT( UINT, csize ), _MAX); tvar >>= csize; \
+	NDRTE_CMPLXT_SPLIT_ASSIGN_7( tvar, csize, __VA_ARGS__ )
+#define NDRTE_CMPLXT_SPLIT_ASSIGN_9( tvar, csize, arg, ... ) \
+	arg = tvar & NDRTE_PP_CAT( NDRTE_PP_CAT( UINT, csize ), _MAX); tvar >>= csize; \
+	NDRTE_CMPLXT_SPLIT_ASSIGN_8( tvar, csize, __VA_ARGS__ )
+#define NDRTE_CMPLXT_SPLIT_ASSIGN_10( tvar, csize, arg, ... ) \
+	arg = tvar & NDRTE_PP_CAT( NDRTE_PP_CAT( UINT, csize ), _MAX); tvar >>= csize; \
+	NDRTE_CMPLXT_SPLIT_ASSIGN_9( tvar, csize, __VA_ARGS__ )
+#define NDRTE_CMPLXT_SPLIT_ASSIGN_11( tvar, csize, arg, ... ) \
+	arg = tvar & NDRTE_PP_CAT( NDRTE_PP_CAT( UINT, csize ), _MAX); tvar >>= csize; \
+	NDRTE_CMPLXT_SPLIT_ASSIGN_10( tvar, csize, __VA_ARGS__ )
+#define NDRTE_CMPLXT_SPLIT_ASSIGN_12( tvar, csize, arg, ... ) \
+	arg = tvar & NDRTE_PP_CAT( NDRTE_PP_CAT( UINT, csize ), _MAX); tvar >>= csize; \
+	NDRTE_CMPLXT_SPLIT_ASSIGN_11( tvar, csize, __VA_ARGS__ )
+#define NDRTE_CMPLXT_SPLIT_ASSIGN_13( tvar, csize, arg, ... ) \
+	arg = tvar & NDRTE_PP_CAT( NDRTE_PP_CAT( UINT, csize ), _MAX); tvar >>= csize; \
+	NDRTE_CMPLXT_SPLIT_ASSIGN_12( tvar, csize, __VA_ARGS__ )
+#define NDRTE_CMPLXT_SPLIT_ASSIGN_14( tvar, csize, arg, ... ) \
+	arg = tvar & NDRTE_PP_CAT( NDRTE_PP_CAT( UINT, csize ), _MAX); tvar >>= csize; \
+	NDRTE_CMPLXT_SPLIT_ASSIGN_13( tvar, csize, __VA_ARGS__ )
+#define NDRTE_CMPLXT_SPLIT_ASSIGN_15( tvar, csize, arg, ... ) \
+	arg = tvar & NDRTE_PP_CAT( NDRTE_PP_CAT( UINT, csize ), _MAX); tvar >>= csize; \
+	NDRTE_CMPLXT_SPLIT_ASSIGN_14( tvar, csize, __VA_ARGS__ )
+#define NDRTE_CMPLXT_SPLIT_ASSIGN_16( tvar, csize, arg, ... ) \
+	arg = tvar & NDRTE_PP_CAT( NDRTE_PP_CAT( UINT, csize ), _MAX); tvar >>= csize; \
+	NDRTE_CMPLXT_SPLIT_ASSIGN_15( tvar, csize, __VA_ARGS__ )
+#define NDRTE_CMPLXT_SPLIT_ASSIGN_( N, tvar, csize, arg, ... ) NDRTE_PP_CAT( NDRTE_CMPLXT_SPLIT_ASSIGN_, N ) ( tvar, csize, arg, __VA_ARGS__ )
+#define NDRTE_CMPLXT_SPLIT_ASSIGN( tvar, csize, arg, ... ) NDRTE_CMPLXT_SPLIT_ASSIGN_( NDRTE_PP_NARG( arg, __VA_ARGS__ ), tvar, csize, arg, __VA_ARGS__ )
+
+#define ndrte_cmplxt_split_generic( tvar, csize, ... ) \
+	NDRTE_CMPLXT_SPLIT_ASSIGN( tvar, csize, __VA_ARGS__ )
+
+#define ndrte_cmplxt_split_signed( tvar, csize, ... ) \
+	{ \
+		ndrte_typeof( tvar ) __tvar = tvar; \
+		ndrte_cmplxt_split_generic( __tvar, csize, __VA_ARGS__ ); \
+	}
+#define ndrte_cmplxt_split_unsigned( tvar, csize, ... ) \
+	{ \
+		ndrte_typeof( tvar ) __tvar = tvar; \
+		ndrte_cmplxt_split_generic( __tvar, csize, __VA_ARGS__ ); \
+	}
+#define ndrte_cmplxt_split_signed_safe( tvar, csize, ... ) \
+	{ \
+		ndrte_typeof( tvar ) __tvar = tvar; \
+		NDRTE_CMPLXT_COMMON_TCHK( NDRTE_PP_CAT(NDRTE_PP_CAT( int, csize ), _t ), __VA_ARGS__ ); \
+		ndrte_cmplxt_split_generic( __tvar, csize, __VA_ARGS__ ); \
+	}
+#define ndrte_cmplxt_split_unsigned_safe( tvar, csize, ... ) \
+	{ \
+		ndrte_typeof( tvar ) __tvar = tvar; \
+		NDRTE_CMPLXT_COMMON_TCHK( NDRTE_PP_CAT(NDRTE_PP_CAT( uint, csize ), _t ), __VA_ARGS__ ); \
+		ndrte_cmplxt_split_generic(  __tvar, csize, __VA_ARGS__ ); \
+	}
+
+#endif

--- a/compdeps/gcc/ndrte_compiler_common.h
+++ b/compdeps/gcc/ndrte_compiler_common.h
@@ -15,7 +15,7 @@
 #define ndrte_builtin_const( x ) __builtin_constant_p( x )
 #define ndrte_likely( x ) __builtin_expect( (x), 1 )
 #define ndrte_unlikely( x ) __builtin_expect( (x), 0 )
-#define ndrte_typeof( x ) __typeof__(x)
+#define ndrte_typeof( x ) __typeof__( x )
 
 #define NDRTE_UOPTR( type ) \
 	__volatile__ type *
@@ -25,5 +25,40 @@
 
 #define NDRTE_ACCESS_ONCE( var ) \
 	(*ndrte_uoptr_set( var ))
+
+#define ndrte_base_of( struct_ptr, member_ptr, member ) \
+	({struct_ptr = (ndrte_typeof( struct_ptr ))((void *)member_ptr) - (void *)&(((ndrte_typeof( struct_ptr ))0)->member); struct_ptr;})
+
+#define ndrte_container_of( obj_ptr, struct_type, member ) \
+	({struct_type *__ret_ptr; ndrte_base_of( __ret_ptr, obj_ptr, member ); __ret_ptr})
+
+#define ndrte_typechk( type, x ) \
+	{ ndrte_typeof( x ) *__checker_0 = (type *)0; }
+
+#define NDRTE_PP_RSEQ_N() \
+	16, 15, 14, 13, \
+	12, 11, 10, 9, \
+	8, 7, 6, 5, \
+	4, 3, 2, 1, 0
+#define NDRTE_PP_ARG_N( \
+	_1, _2, _3, _4, \
+	_5, _6, _7, _8, \
+	_9, _10, _11, _12, \
+	_13, _14, _15, _16, N, ... \
+) N
+#define NDRTE_PP_NARG_( ... ) \
+	NDRTE_PP_ARG_N( __VA_ARGS__ )
+#define NDRTE_PP_NARG( ... ) \
+	NDRTE_PP_NARG_( __VA_ARGS__, NDRTE_PP_RSEQ_N() )
+
+#define NDRTE_PP_CAT( x, y ) \
+	NDRTE_PP_CAT_DEPTH1( x, y )
+#define NDRTE_PP_CAT_DEPTH1( x, y ) \
+	NDRTE_PP_CAT_DEPTH2( x, y )
+#define NDRTE_PP_CAT_DEPTH2( x, y ) x ## y
+
+#include "ndrte_compiler_cmplxt_define.h"
+#include "ndrte_compiler_cmplxt_pack.h"
+#include "ndrte_compiler_cmplxt_split.h"
 
 #endif

--- a/datastructs/lockfree/Makefile
+++ b/datastructs/lockfree/Makefile
@@ -1,8 +1,6 @@
 OBJ += dst_lockfree
 
 HDRS += ndrte_lfqueue.h
-HDRS += ndrte_lflist.h
-HDRS += ndrte_lfhash.h
 
 SRCS += ndrte_lfqueue.c
 

--- a/datastructs/lockfree/ndrte_lfhash.h
+++ b/datastructs/lockfree/ndrte_lfhash.h
@@ -1,4 +1,0 @@
-#ifndef NDRTE_LFHASH_H
-#define NDRTE_LFHASH_H
-
-#endif

--- a/datastructs/lockfree/ndrte_lflist.h
+++ b/datastructs/lockfree/ndrte_lflist.h
@@ -1,6 +1,0 @@
-#ifndef NDRTE_LFLIST_H
-#define NDRTE_LFLIST_H
-
-
-
-#endif

--- a/test/perftest/perftest_common.h
+++ b/test/perftest/perftest_common.h
@@ -1,5 +1,5 @@
-#ifndef NDR_TEST_COMMON_H
-#define NDR_TEST_COMMON_H
+#ifndef NDR_PERFTEST_COMMON_H
+#define NDR_PERFTEST_COMMON_H
 
 #include "pthread.h"
 #include "nts.h"

--- a/test/selftest/Makefile
+++ b/test/selftest/Makefile
@@ -2,8 +2,11 @@ COVAPP = selftest
 
 DEPLIBS += pthread
 
+SRCS += selftest_compdeps_cmplxt.c
+
 SRCS += selftest_queue.c
 SRCS += selftest_lfqueue.c
+
 SRCS += selftest.c
 
 include $(NBE_DIR)/ndr.debug.mk

--- a/test/selftest/selftest.c
+++ b/test/selftest/selftest.c
@@ -1,9 +1,13 @@
 #include "selftest.h"
 
-#include "ndrte_arch_endian.h"
-
 int main( int argc, char **argv )
 {
+	NTS_CALL_TC( compdeps_cmplxt_i32 );
+	NTS_REPORT( compdeps_cmplxt_i32 );
+
+	NTS_CALL_TC( compdeps_cmplxt_u32 );
+	NTS_REPORT( compdeps_cmplxt_u32 );
+
 	NTS_CALL_TC( queue_single );
 	NTS_REPORT( queue_single );
 

--- a/test/selftest/selftest.h
+++ b/test/selftest/selftest.h
@@ -1,6 +1,8 @@
 #ifndef NDR_SELFTEST_H
 #define NDR_SELFTEST_H
 
+#include "selftest_compdeps_cmplxt.h"
+
 #include "selftest_queue.h"
 #include "selftest_lfqueue.h"
 

--- a/test/selftest/selftest_common.h
+++ b/test/selftest/selftest_common.h
@@ -1,5 +1,5 @@
-#ifndef NDR_TEST_COMMON_H
-#define NDR_TEST_COMMON_H
+#ifndef NDR_SELFTEST_COMMON_H
+#define NDR_SELFTEST_COMMON_H
 
 #include "pthread.h"
 #include "nts.h"

--- a/test/selftest/selftest_compdeps_cmplxt.c
+++ b/test/selftest/selftest_compdeps_cmplxt.c
@@ -1,0 +1,145 @@
+#include "ndrte_compiler_common.h"
+
+#include "selftest_compdeps_cmplxt.h"
+
+NTS_DEFINE_TC( compdeps_cmplxt_i32 )
+{
+	union
+	{
+		uint32_t var;
+		struct
+		{
+			int16_t v16_0, v16_1;
+		};
+		struct
+		{
+			int8_t v8_0, v8_1, v8_2, v8_3;
+		};
+	} test;
+
+	int16_t t16_0, t16_1;
+	int8_t t8_0, t8_1, t8_2, t8_3;
+
+	ndrte_cmplxt_pack_signed( test.var, 8, -1, -2, -3, -4 );
+	NTS_CHECK_LVL( compdeps_cmplxt_i32, test.v8_0 == -1, NTS_LVLSILENT );
+	NTS_CHECK_LVL( compdeps_cmplxt_i32, test.v8_1 == -2, NTS_LVLSILENT );
+	NTS_CHECK_LVL( compdeps_cmplxt_i32, test.v8_2 == -3, NTS_LVLSILENT );
+	NTS_CHECK_LVL( compdeps_cmplxt_i32, test.v8_3 == -4, NTS_LVLSILENT );
+
+	ndrte_cmplxt_split_signed( test.var, 8, t8_0, t8_1, t8_2, t8_3 );
+	NTS_CHECK_LVL( compdeps_cmplxt_i32, test.v8_0 == -1, NTS_LVLSILENT );
+	NTS_CHECK_LVL( compdeps_cmplxt_i32, test.v8_1 == -2, NTS_LVLSILENT );
+	NTS_CHECK_LVL( compdeps_cmplxt_i32, test.v8_2 == -3, NTS_LVLSILENT );
+	NTS_CHECK_LVL( compdeps_cmplxt_i32, test.v8_3 == -4, NTS_LVLSILENT );
+	NTS_CHECK_LVL( compdeps_cmplxt_i32, t8_0 == -1, NTS_LVLSILENT );
+	NTS_CHECK_LVL( compdeps_cmplxt_i32, t8_1 == -2, NTS_LVLSILENT );
+	NTS_CHECK_LVL( compdeps_cmplxt_i32, t8_2 == -3, NTS_LVLSILENT );
+	NTS_CHECK_LVL( compdeps_cmplxt_i32, t8_3 == -4, NTS_LVLSILENT );
+
+	ndrte_cmplxt_pack_signed( test.var, 16, -10, -20 );
+	NTS_CHECK_LVL( compdeps_cmplxt_i32, test.v16_0 == -10, NTS_LVLSILENT );
+	NTS_CHECK_LVL( compdeps_cmplxt_i32, test.v16_1 == -20, NTS_LVLSILENT );
+
+	ndrte_cmplxt_split_signed( test.var, 16, t16_0, t16_1 );
+	NTS_CHECK_LVL( compdeps_cmplxt_i32, test.v16_0 == -10, NTS_LVLSILENT );
+	NTS_CHECK_LVL( compdeps_cmplxt_i32, test.v16_1 == -20, NTS_LVLSILENT );
+	NTS_CHECK_LVL( compdeps_cmplxt_i32, t16_0 == -10, NTS_LVLSILENT );
+	NTS_CHECK_LVL( compdeps_cmplxt_i32, t16_1 == -20, NTS_LVLSILENT );
+
+	ndrte_cmplxt_pack_signed_safe( test.var, 8, (int8_t)-1, (int8_t)-2, (int8_t)-3, (int8_t)-4 );
+	NTS_CHECK_LVL( compdeps_cmplxt_i32, test.v8_0 == -1, NTS_LVLSILENT );
+	NTS_CHECK_LVL( compdeps_cmplxt_i32, test.v8_1 == -2, NTS_LVLSILENT );
+	NTS_CHECK_LVL( compdeps_cmplxt_i32, test.v8_2 == -3, NTS_LVLSILENT );
+	NTS_CHECK_LVL( compdeps_cmplxt_i32, test.v8_3 == -4, NTS_LVLSILENT );
+
+	ndrte_cmplxt_split_signed_safe( test.var, 8, t8_0, t8_1, t8_2, t8_3 );
+	NTS_CHECK_LVL( compdeps_cmplxt_i32, test.v8_0 == -1, NTS_LVLSILENT );
+	NTS_CHECK_LVL( compdeps_cmplxt_i32, test.v8_1 == -2, NTS_LVLSILENT );
+	NTS_CHECK_LVL( compdeps_cmplxt_i32, test.v8_2 == -3, NTS_LVLSILENT );
+	NTS_CHECK_LVL( compdeps_cmplxt_i32, test.v8_3 == -4, NTS_LVLSILENT );
+	NTS_CHECK_LVL( compdeps_cmplxt_i32, t8_0 == -1, NTS_LVLSILENT );
+	NTS_CHECK_LVL( compdeps_cmplxt_i32, t8_1 == -2, NTS_LVLSILENT );
+	NTS_CHECK_LVL( compdeps_cmplxt_i32, t8_2 == -3, NTS_LVLSILENT );
+	NTS_CHECK_LVL( compdeps_cmplxt_i32, t8_3 == -4, NTS_LVLSILENT );
+
+	ndrte_cmplxt_pack_signed_safe( test.var, 16, (int16_t)-10, (int16_t)-20 );
+	NTS_CHECK_LVL( compdeps_cmplxt_i32, test.v16_0 == -10, NTS_LVLSILENT );
+	NTS_CHECK_LVL( compdeps_cmplxt_i32, test.v16_1 == -20, NTS_LVLSILENT );
+
+	ndrte_cmplxt_split_signed_safe( test.var, 16, t16_0, t16_1 );
+	NTS_CHECK_LVL( compdeps_cmplxt_i32, test.v16_0 == -10, NTS_LVLSILENT );
+	NTS_CHECK_LVL( compdeps_cmplxt_i32, test.v16_1 == -20, NTS_LVLSILENT );
+	NTS_CHECK_LVL( compdeps_cmplxt_i32, t16_0 == -10, NTS_LVLSILENT );
+	NTS_CHECK_LVL( compdeps_cmplxt_i32, t16_1 == -20, NTS_LVLSILENT );
+}
+
+NTS_DEFINE_TC( compdeps_cmplxt_u32 )
+{
+	union
+	{
+		uint32_t var;
+		struct
+		{
+			uint16_t v16_0, v16_1;
+		};
+		struct
+		{
+			uint8_t v8_0, v8_1, v8_2, v8_3;
+		};
+	} test;
+
+	uint16_t t16_0, t16_1;
+	uint8_t t8_0, t8_1, t8_2, t8_3;
+
+	ndrte_cmplxt_pack_unsigned( test.var, 8, 1, 2, 3, 4 );
+	NTS_CHECK_LVL( compdeps_cmplxt_u32, test.v8_0 == 1, NTS_LVLSILENT );
+	NTS_CHECK_LVL( compdeps_cmplxt_u32, test.v8_1 == 2, NTS_LVLSILENT );
+	NTS_CHECK_LVL( compdeps_cmplxt_u32, test.v8_2 == 3, NTS_LVLSILENT );
+	NTS_CHECK_LVL( compdeps_cmplxt_u32, test.v8_3 == 4, NTS_LVLSILENT );
+
+	ndrte_cmplxt_split_unsigned( test.var, 8, t8_0, t8_1, t8_2, t8_3 );
+	NTS_CHECK_LVL( compdeps_cmplxt_u32, test.v8_0 == 1, NTS_LVLSILENT );
+	NTS_CHECK_LVL( compdeps_cmplxt_u32, test.v8_1 == 2, NTS_LVLSILENT );
+	NTS_CHECK_LVL( compdeps_cmplxt_u32, test.v8_2 == 3, NTS_LVLSILENT );
+	NTS_CHECK_LVL( compdeps_cmplxt_u32, test.v8_3 == 4, NTS_LVLSILENT );
+	NTS_CHECK_LVL( compdeps_cmplxt_u32, t8_0 == 1, NTS_LVLSILENT );
+	NTS_CHECK_LVL( compdeps_cmplxt_u32, t8_1 == 2, NTS_LVLSILENT );
+	NTS_CHECK_LVL( compdeps_cmplxt_u32, t8_2 == 3, NTS_LVLSILENT );
+	NTS_CHECK_LVL( compdeps_cmplxt_u32, t8_3 == 4, NTS_LVLSILENT );
+
+	ndrte_cmplxt_pack_unsigned( test.var, 16, 10, 20 );
+	NTS_CHECK_LVL( compdeps_cmplxt_u32, test.v16_0 == 10, NTS_LVLSILENT );
+	NTS_CHECK_LVL( compdeps_cmplxt_u32, test.v16_1 == 20, NTS_LVLSILENT );
+
+	ndrte_cmplxt_split_unsigned( test.var, 16, t16_0, t16_1 );
+	NTS_CHECK_LVL( compdeps_cmplxt_u32, test.v16_0 == 10, NTS_LVLSILENT );
+	NTS_CHECK_LVL( compdeps_cmplxt_u32, test.v16_1 == 20, NTS_LVLSILENT );
+	NTS_CHECK_LVL( compdeps_cmplxt_u32, t16_0 == 10, NTS_LVLSILENT );
+	NTS_CHECK_LVL( compdeps_cmplxt_u32, t16_1 == 20, NTS_LVLSILENT );
+
+	ndrte_cmplxt_pack_unsigned_safe( test.var, 8, (uint8_t)1, (uint8_t)2, (uint8_t)3, (uint8_t)4 );
+	NTS_CHECK_LVL( compdeps_cmplxt_u32, test.v8_0 == 1, NTS_LVLSILENT );
+	NTS_CHECK_LVL( compdeps_cmplxt_u32, test.v8_1 == 2, NTS_LVLSILENT );
+	NTS_CHECK_LVL( compdeps_cmplxt_u32, test.v8_2 == 3, NTS_LVLSILENT );
+	NTS_CHECK_LVL( compdeps_cmplxt_u32, test.v8_3 == 4, NTS_LVLSILENT );
+
+	ndrte_cmplxt_split_unsigned_safe( test.var, 8, t8_0, t8_1, t8_2, t8_3 );
+	NTS_CHECK_LVL( compdeps_cmplxt_u32, test.v8_0 == 1, NTS_LVLSILENT );
+	NTS_CHECK_LVL( compdeps_cmplxt_u32, test.v8_1 == 2, NTS_LVLSILENT );
+	NTS_CHECK_LVL( compdeps_cmplxt_u32, test.v8_2 == 3, NTS_LVLSILENT );
+	NTS_CHECK_LVL( compdeps_cmplxt_u32, test.v8_3 == 4, NTS_LVLSILENT );
+	NTS_CHECK_LVL( compdeps_cmplxt_u32, t8_0 == 1, NTS_LVLSILENT );
+	NTS_CHECK_LVL( compdeps_cmplxt_u32, t8_1 == 2, NTS_LVLSILENT );
+	NTS_CHECK_LVL( compdeps_cmplxt_u32, t8_2 == 3, NTS_LVLSILENT );
+	NTS_CHECK_LVL( compdeps_cmplxt_u32, t8_3 == 4, NTS_LVLSILENT );
+
+	ndrte_cmplxt_pack_unsigned_safe( test.var, 16, (uint16_t)10, (uint16_t)20 );
+	NTS_CHECK_LVL( compdeps_cmplxt_u32, test.v16_0 == 10, NTS_LVLSILENT );
+	NTS_CHECK_LVL( compdeps_cmplxt_u32, test.v16_1 == 20, NTS_LVLSILENT );
+
+	ndrte_cmplxt_split_unsigned_safe( test.var, 16, t16_0, t16_1 );
+	NTS_CHECK_LVL( compdeps_cmplxt_u32, test.v16_0 == 10, NTS_LVLSILENT );
+	NTS_CHECK_LVL( compdeps_cmplxt_u32, test.v16_1 == 20, NTS_LVLSILENT );
+	NTS_CHECK_LVL( compdeps_cmplxt_u32, t16_0 == 10, NTS_LVLSILENT );
+	NTS_CHECK_LVL( compdeps_cmplxt_u32, t16_1 == 20, NTS_LVLSILENT );
+}

--- a/test/selftest/selftest_compdeps_cmplxt.h
+++ b/test/selftest/selftest_compdeps_cmplxt.h
@@ -1,0 +1,9 @@
+#ifndef NDR_SELFTEST_COMPDEPS_CMPLXT_H
+#define NDR_SELFTEST_COMPDEPS_CMPLXT_H
+
+#include "selftest_common.h"
+
+NTS_DECLARE_TC( compdeps_cmplxt_i32 );
+NTS_DECLARE_TC( compdeps_cmplxt_u32 );
+
+#endif


### PR DESCRIPTION
Add the set of codes to manipulate custom vectorized type.

For example, we can use a uint128_t variable as a vectorized set of two
uint64_t variables.